### PR TITLE
Conformed copy button styling, made only first text editable and removed copy buttons where not needed

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -86,7 +86,7 @@ function send() {
   </div>
   <div v-else>
     <div class="parts">
-      <Text title="Final text" :text="proofed" v-on:updated="updated" v-on:selected="selectParagraph"></Text>
+      <Text :editable="true" title="Edit here" :text="proofed" v-on:updated="updated" v-on:selected="selectParagraph"></Text>
       <Text title="Submitted with changes" :text="proofed" :original="original" :selectedParagraph="selectedParagraph"></Text>
       <Text title="English text" :text="english" :selectedParagraph="selectedParagraph"></Text>
     </div>

--- a/src/components/AppButton.vue
+++ b/src/components/AppButton.vue
@@ -4,6 +4,10 @@ defineProps({
   type: {
     type: String,
     default: 'primary'
+  },
+  disabled: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -12,7 +16,7 @@ defineEmits(['click'])
 </script>
 
 <template>
-    <button :class="type" @click="$emit('click')"><slot></slot></button>
+    <button :disabled="disabled" :class="type" @click="$emit('click')"><slot></slot></button>
 </template>
 
 <style scoped>
@@ -28,6 +32,11 @@ button {
 
 button:focus {
   outline: none;
+}
+
+button:disabled {
+    opacity: 0.4;
+    cursor: default;
 }
 
 button.primary {

--- a/src/components/Text.vue
+++ b/src/components/Text.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import AppButton from './AppButton.vue'
 import { ref, computed } from 'vue'
 import { diffChars } from 'diff'
 
@@ -6,6 +7,10 @@ const props = defineProps({
   title: {
     type: String,
     required: true
+  },
+  editable: {
+    type: Boolean,
+    default: false
   },
   text: {
     type: String,
@@ -83,13 +88,13 @@ const noChanges = computed(() => {
     <div class="alert" v-if="noChanges">
       No changes
     </div>
-    <p v-for="content, index of paragraphs" v-bind:class="{ 'selected': selectedParagraph === index, 'copied': copied }" v:key="content" contenteditable="true" v-on:focus="emit('selected', index)" v-on:blur="bindValue($event, index)">
+    <p v-for="content, index of paragraphs" v-bind:class="{ 'selected': selectedParagraph === index, 'copied': copied }" v:key="content" :contenteditable="editable" v-on:focus="emit('selected', index)" v-on:blur="bindValue($event, index)">
       <span v-if="isString(content)">{{ content }}</span>
       <div v-else>
         <span v-for="part of content" v:key="part.value" :class="getClass(part)">{{ part.value }}</span>
       </div>
     </p>
-    <button v-on:click="copy" :disabled="copied">{{ copied ? 'copied..' : 'copy' }}</button>
+    <AppButton v-if="editable" v-on:click="copy" :disabled="copied">{{ copied ? 'copied..' : 'copy' }}</AppButton>
   </div>
 </template>
 
@@ -146,7 +151,6 @@ const noChanges = computed(() => {
 .added {
   background-color: rgb(182, 255, 182);
   padding: 0 4px;
-
 }
 
 </style>


### PR DESCRIPTION
I removed the contenteditable on the English and diff texts as they should not be edited.

Furthermore, without contenteditable, these can be selected and copied as-is, so I removed the copy button for these.

Finally, I switched the copy-button to use the new AppButton for conformity, but I think this need to be less accentuated, so I will change it to a link button instead later.

![image](https://user-images.githubusercontent.com/8461739/199140878-c1787377-a27d-4627-9f9e-1d8606f987df.png)


