### PR TITLE
Adding landing page

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,9 +4,11 @@ import ProofreadPage from '@/usecases/proofread/ProofreadPage.vue'
 import ReviewPage from '@/usecases/review/ReviewPage.vue'
 import DemoPage from '@/usecases/demo/DemoPage.vue'
 import NotFoundPage from '@/usecases/not-found/NotFoundPage.vue'
+import IndexPage from '@/usecases/home/IndexPage.vue'
 
 const routes = [
-    { path: '/', component: ProofreadPage },
+    { path: '/', component: IndexPage },
+    { path: '/proof-read', component: ProofreadPage },
     { path: '/review/:articleId', component: ReviewPage },
     { path: '/demo', component: DemoPage },
     { path: '/:pathMatch(.*)*', component: NotFoundPage },

--- a/src/usecases/home/IndexPage.vue
+++ b/src/usecases/home/IndexPage.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+
+import AppButton from '@/components/AppButton.vue';
+import { useRouter } from 'vue-router';
+
+const router = useRouter()
+
+function goto(path: string) {
+    router.push(path);
+}
+
+</script>
+
+<template>
+    <div class="page-container">
+        <h1>Japanese proof-reading</h1>
+        <p>This site holds proof-reading tools and review tools for Japanese texts.</p>
+        <p>It was built as a part of a service called JWriter which later got closed due to a lack of usage.</p>
+        <p>For now, this tool is still possible to use though, we have a few example articles you can try proof-reading and you may also want to check the proof-reader editor inteface.</p>
+        <div class="buttons">
+            <AppButton @click="goto('/demo')">Demo</AppButton>
+            <AppButton @click="goto('/proof-read')">Proof-reading</AppButton>
+        </div>
+        <p>
+            You may also be interested in the full source code for this project at <a href="https://github.com/Greycastle/jwriter-proofing">GitHub</a>
+        </p>
+    </div>
+</template>
+
+<style scoped>
+.buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 32px;
+    justify-content: center;
+}
+</style>


### PR DESCRIPTION
Adding a root-url landing page to make the project stand on its own without the jwriter softr project to back it.

![image](https://user-images.githubusercontent.com/8461739/206975411-9001d026-328d-4abb-9ab9-4b56096301fb.png)


To make this actually functional, I need to embed the API key to airtable as well because this is currently provided by the softr application.